### PR TITLE
Craftitem: add in torch group

### DIFF
--- a/torches.lua
+++ b/torches.lua
@@ -18,6 +18,7 @@ for i in ipairs(colour_list) do
 		inventory_image = "abritorch_torch_on_floor_"..colour..".png",
 		wield_image = "abritorch_torch_on_floor_"..colour..".png",
 		wield_scale = {x = 1, y = 1, z = 1 + 1/16},
+		groups = { torch = 1 },
 		liquids_pointable = false,
 		on_place = function(itemstack, placer, pointed_thing)
 			local above = pointed_thing.above


### PR DESCRIPTION
In world nodes belongs to group torch, but not craftitem.

From unified inventory if you search group:torch you can reach default:torch but not the one from abritorch.

It could greatly help me to check items are torches in my version of maidroid.
