### PR TITLE
Make torches create particle spawners only during on_construct() and in LBM

### DIFF
--- a/torches.lua
+++ b/torches.lua
@@ -200,3 +200,24 @@ if minetest.features.particlespawner_tweenable then
 		end
 	})
 end
+
+
+local CHECK_INTERVAL = 7.777
+local last_check = 0
+local clear_unloaded_particles = function(dtime)
+	last_check = last_check + dtime
+	if last_check < CHECK_INTERVAL then
+		return
+	else
+		last_check = last_check - CHECK_INTERVAL
+	end
+	for pos_hash, spawner_id in pairs(active_particle_spawners) do
+		local pos = minetest.get_position_from_hash(pos_hash)
+		if not minetest.get_node_or_nil(pos) then
+			minetest.delete_particlespawner(spawner_id)
+			active_particle_spawners[pos_hash] = nil
+		end
+	end
+end
+
+minetest.register_globalstep(clear_unloaded_particles)

--- a/torches.lua
+++ b/torches.lua
@@ -213,7 +213,8 @@ local clear_unloaded_particles = function(dtime)
 	end
 	for pos_hash, spawner_id in pairs(active_particle_spawners) do
 		local pos = minetest.get_position_from_hash(pos_hash)
-		if not minetest.get_node_or_nil(pos) then
+		local node = minetest.get_node_or_nil(pos)
+		if (not node) or node.name:find("^abritorch:") == nil then
 			minetest.delete_particlespawner(spawner_id)
 			active_particle_spawners[pos_hash] = nil
 		end


### PR DESCRIPTION
Prevent spamming network with particle spawner creation packets each second. Spawners are created and destroyed together with the torch node, and re-created in lbm after server restart.

We have a place on our server with lots of abritorches. It constantly generates 200 packets per second (2 packets per torch, because they become split packets...). Maybe it's not that much, but it adds up with other things happening...